### PR TITLE
refactor : 알림 조회 시 User 조회 횟수 단축

### DIFF
--- a/src/main/java/sns/snsproject/controller/UserController.java
+++ b/src/main/java/sns/snsproject/controller/UserController.java
@@ -11,8 +11,11 @@ import sns.snsproject.controller.response.AlarmResponse;
 import sns.snsproject.controller.response.Response;
 import sns.snsproject.controller.response.UserJoinResponse;
 import sns.snsproject.controller.response.UserLoginResponse;
+import sns.snsproject.exception.ErrorCode;
+import sns.snsproject.exception.SnsApplicationException;
 import sns.snsproject.model.User;
 import sns.snsproject.service.UserService;
+import sns.snsproject.util.ClassUtils;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -35,6 +38,8 @@ public class UserController {
 
     @GetMapping("/alarm")
     public Response<Page<AlarmResponse>> alarm(Pageable pageable, Authentication authentication) {
-        return Response.success(userService.alarmList(authentication.getName(), pageable).map(AlarmResponse::fromAlarm));
+        User user = ClassUtils.getSafeCastInstance(authentication.getPrincipal(), User.class).orElseThrow(
+                () -> new SnsApplicationException(ErrorCode.INTERNAL_SERVER_ERROR, String.format("Casting to User class failed")));
+        return Response.success(userService.alarmList(user.getId(), pageable).map(AlarmResponse::fromAlarm));
     }
 }

--- a/src/main/java/sns/snsproject/repository/AlarmEntityRepository.java
+++ b/src/main/java/sns/snsproject/repository/AlarmEntityRepository.java
@@ -4,8 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sns.snsproject.model.entity.AlarmEntity;
-import sns.snsproject.model.entity.UserEntity;
 
 public interface AlarmEntityRepository extends JpaRepository<AlarmEntity, Long> {
-    Page<AlarmEntity> findAllByUser(UserEntity user, Pageable pageable);
+    Page<AlarmEntity> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/sns/snsproject/service/UserService.java
+++ b/src/main/java/sns/snsproject/service/UserService.java
@@ -56,9 +56,8 @@ public class UserService {
         return token;
     }
 
-    public Page<Alarm> alarmList(String userName, Pageable pageable) {
-        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
-        return alarmEntityRepository.findAllByUser(userEntity, pageable).map(Alarm::fromEntity);
+    public Page<Alarm> alarmList(Long userId, Pageable pageable) {
+        return alarmEntityRepository.findAllByUserId(userId, pageable).map(Alarm::fromEntity);
     }
 
     public User loadUserByUsername(String userName) {

--- a/src/main/java/sns/snsproject/util/ClassUtils.java
+++ b/src/main/java/sns/snsproject/util/ClassUtils.java
@@ -1,0 +1,10 @@
+package sns.snsproject.util;
+
+import java.util.Optional;
+
+public class ClassUtils {
+
+    public static <T> Optional<T> getSafeCastInstance(Object o, Class<T> clazz) {
+        return clazz != null && clazz.isInstance(o) ? Optional.of(clazz.cast(o)) : Optional.empty();
+    }
+}


### PR DESCRIPTION
- 기존 알림 조회 시 User 조회를 토큰 검증 과정과 Service단에서 2번 수행 -> 토근 검증 후 SecurityContextHolder에 저장된 User의 id를 Controller에서 꺼내 넘겨줌으로써 Service단의 User 조회 과정을 제거