### PR TITLE
refactor: FollowEntity를 기준으로 게시글 조회 로직 수정 및 LIMIT 추가

### DIFF
--- a/src/main/java/sns/snsproject/repository/PostEntityRepository.java
+++ b/src/main/java/sns/snsproject/repository/PostEntityRepository.java
@@ -16,17 +16,20 @@ public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 
     Page<PostEntity> findAllByOrderByRegisteredAtDesc(Pageable pageable);
 
-    @Query("SELECT p FROM PostEntity p " +
+    @Query("SELECT p FROM FollowEntity f " +
+            "JOIN PostEntity p ON p.user = f.following " +
             "JOIN FETCH p.user " +
-            "JOIN FollowEntity f ON p.user = f.following " +
             "WHERE f.follower = :user " +
-            "ORDER BY p.id DESC")
-    List<PostEntity> findPostsByFollowerOrderByIdDescWithoutCursor(UserEntity user, Pageable pageable);
+            "ORDER BY p.id DESC " +
+            "LIMIT :pageSize ")
+    List<PostEntity> findPostsByFollowerOrderByIdDescWithoutCursor(UserEntity user, Integer pageSize);
 
-    @Query("SELECT p FROM PostEntity p " +
+
+    @Query("SELECT p FROM FollowEntity f " +
+            "JOIN PostEntity p ON p.user = f.following " +
             "JOIN FETCH p.user " +
-            "JOIN FollowEntity f ON p.user = f.following " +
             "WHERE f.follower = :user AND p.id < :cursorId " +
-            "ORDER BY p.id DESC")
-    List<PostEntity> findPostsByFollowerOrderByIdDesc(UserEntity user, Pageable pageable, Long cursorId);
+            "ORDER BY p.id DESC " +
+            "LIMIT :pageSize ")
+    List<PostEntity> findPostsByFollowerOrderByIdDesc(UserEntity user, Long cursorId, Integer pageSize);
 }

--- a/src/main/java/sns/snsproject/service/PostService.java
+++ b/src/main/java/sns/snsproject/service/PostService.java
@@ -167,13 +167,13 @@ public class PostService {
 
     public List<PostResponse> getPostsFromFollowedUsers(String userName, Integer pageSize, Long cursorId) {
         UserEntity user = getUserEntityOrException(userName);
-        Pageable pageable = PageRequest.of(0, pageSize + 1);
+        pageSize = pageSize + 1;
 
         List<PostEntity> postEntities = new ArrayList<>();
         if (cursorId == 0) {
-            postEntities = postEntityRepository.findPostsByFollowerOrderByIdDescWithoutCursor(user, pageable);
+            postEntities = postEntityRepository.findPostsByFollowerOrderByIdDescWithoutCursor(user, pageSize);
         } else {
-            postEntities = postEntityRepository.findPostsByFollowerOrderByIdDesc(user, pageable, cursorId);
+            postEntities = postEntityRepository.findPostsByFollowerOrderByIdDesc(user, cursorId, pageSize);
         }
         boolean hasNext = hasNext(postEntities.size(), pageSize);
         postEntities = toSubListIfHasNext(hasNext, pageSize, postEntities);


### PR DESCRIPTION
- 기존 쿼리를 FollowEntity를 기준으로 리팩토링하여 가독성 향상
- 페이지 크기를 제한하기 위해 Pageable 대신 LIMIT 사용 추가
- 커서 기반 페이징과 일반 페이징 모두에 적용