### PR TITLE
feat: 낙관적 락 기반 좋아요 기능 및 재시도 로직 도입

### DIFF
--- a/src/main/java/sns/snsproject/controller/PostController.java
+++ b/src/main/java/sns/snsproject/controller/PostController.java
@@ -67,7 +67,7 @@ public class PostController {
 
     @PostMapping("/{postId}/likes")
     public Response<Void> like(@PathVariable Long postId, Authentication authentication) {
-        postService.like(postId, authentication.getName());
+        postService.likeWithRetry(postId, authentication.getName());
         return Response.success();
     }
 

--- a/src/main/java/sns/snsproject/controller/response/PostResponse.java
+++ b/src/main/java/sns/snsproject/controller/response/PostResponse.java
@@ -24,6 +24,8 @@ public class PostResponse {
 
     private Timestamp deletedAt;
 
+    private Integer likeCount;
+
     public static PostResponse fromPost(Post post) {
 
         return new PostResponse(
@@ -33,7 +35,8 @@ public class PostResponse {
                 UserResponse.fromUser(post.getUser()),
                 post.getRegisteredAt(),
                 post.getUpdatedAt(),
-                post.getDeletedAt()
+                post.getDeletedAt(),
+                post.getLikes()
 
         );
     }

--- a/src/main/java/sns/snsproject/exception/ErrorCode.java
+++ b/src/main/java/sns/snsproject/exception/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "Permission is invalid"),
     ALREADY_LIKED(HttpStatus.CONFLICT, "User already liked post"),
     DUPLICATE_FOLLOW(HttpStatus.CONFLICT, "Duplicate Follow"),
-    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW Not Fount")
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW Not Fount"),
+    OPTIMISTIC_LOCK_CONFLICT(HttpStatus.CONFLICT, "Resource update conflict. Please try again"),
+    CONFLICT_LIKE(HttpStatus.CONFLICT,"Resource update conflict. Please try again")
     ;
 
     private HttpStatus status;

--- a/src/main/java/sns/snsproject/model/Post.java
+++ b/src/main/java/sns/snsproject/model/Post.java
@@ -18,6 +18,8 @@ public class Post {
 
     private User user;
 
+    private Integer likes;
+
     private Timestamp registeredAt;
 
     private Timestamp updatedAt;
@@ -30,6 +32,7 @@ public class Post {
                 entity.getTitle(),
                 entity.getBody(),
                 User.fromEntity(entity.getUser()),
+                entity.getLikeCount(),
                 entity.getRegisteredAt(),
                 entity.getUpdatedAt(),
                 entity.getDeletedAt()

--- a/src/main/java/sns/snsproject/model/entity/PostEntity.java
+++ b/src/main/java/sns/snsproject/model/entity/PostEntity.java
@@ -41,6 +41,13 @@ public class PostEntity {
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 
+    @Column(name = "like_count")
+    private Integer likeCount = 0;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     @PrePersist
     void registeredAT() {
         this.registeredAt = Timestamp.from(Instant.now());
@@ -49,6 +56,16 @@ public class PostEntity {
     @PreUpdate
     void updatedAt() {
         this.updatedAt = Timestamp.from(Instant.now());
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
     }
 
     public static PostEntity of(String title, String body, UserEntity user) {

--- a/src/main/java/sns/snsproject/repository/LikeEntityRepository.java
+++ b/src/main/java/sns/snsproject/repository/LikeEntityRepository.java
@@ -1,9 +1,11 @@
 package sns.snsproject.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import sns.snsproject.model.entity.LikeEntity;
 import sns.snsproject.model.entity.PostEntity;
 import sns.snsproject.model.entity.UserEntity;
@@ -17,4 +19,12 @@ public interface LikeEntityRepository extends JpaRepository<LikeEntity, Long> {
 
     @Query(value = "select count(*) from LikeEntity entity where entity.post = :post")
     long countByPost(@Param("post") PostEntity postEntity);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM LikeEntity where id = :likeId")
+    void deleteLike(@Param("likeId") Long likeId);
+
+    @Query("SELECT COUNT(e) > 0 FROM LikeEntity e WHERE e.user = :user AND e.post.id = :postId")
+    boolean existsByUserAndPost(@Param("user") UserEntity user, @Param("postId") Long postId);
 }

--- a/src/main/java/sns/snsproject/service/PostService.java
+++ b/src/main/java/sns/snsproject/service/PostService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -128,19 +129,51 @@ public class PostService {
         return postEntityRepository.findAllByUser(userEntity, pageable).map(Post::fromEntity);
     }
 
+    public void likeWithRetry(Long postId, String userName) {
+        int retry = 0;
+        long startTime = System.currentTimeMillis();
+        while (retry < 10) {
+            try {
+                like(postId, userName);
+                long endTime = System.currentTimeMillis();
+                logSuccess(userName, retry, endTime - startTime);
+                return;
+            } catch (ObjectOptimisticLockingFailureException e) {
+                retry++;
+                System.out.println("🔁 낙관적 락 재시도 #" + retry);
+            }catch (SnsApplicationException e) {
+                long endTime = System.currentTimeMillis();
+                logFailure(userName, retry, endTime - startTime, e.getMessage());
+                return;
+            }
+        }
+//        throw new SnsApplicationException(ErrorCode.CONFLICT_LIKE, "동시 요청 충돌, 나중에 다시 시도해주세요.");
+        long endTime = System.currentTimeMillis();
+        logFailure(userName, retry, endTime - startTime, "재시도 초과");
+    }
+    private void logSuccess(String userName, int retry, long durationMs) {
+        System.out.printf("[Thread-%s] ✅ 성공 | 재시도: %d회 | 소요시간: %dms%n", userName, retry, durationMs);
+    }
+
+    private void logFailure(String userName, int retry, long durationMs, String reason) {
+        System.out.printf("[Thread-%s] ❌ 실패 | 재시도: %d회 | 소요시간: %dms | 예외: %s%n", userName, retry, durationMs, reason);
+    }
+
     @Transactional
     public void like(Long postId, String userName) {
 
         UserEntity userEntity = getUserEntityOrException(userName);
         PostEntity postEntity = getPostEntityOrException(postId);
 
-        // check like
-        likeEntityRepository.findByUserAndPost(userEntity, postEntity).ifPresent(it -> {
+        // 불필요한 데이터 로딩을 줄여 성능과 명확성을 높이기 위해 리팩토링
+        boolean alreadyLiked = likeEntityRepository.existsByUserAndPost(userEntity, postId);
+        if (alreadyLiked) {
             throw new SnsApplicationException(ErrorCode.ALREADY_LIKED, String.format("userName %s already like post %d", userName, postId));
-        });
+        }
 
+        postEntity.incrementLikeCount();
+        postEntityRepository.saveAndFlush(postEntity);
         likeEntityRepository.save(LikeEntity.of(userEntity, postEntity));
-
         alarmEntityRepository.save(AlarmEntity.of(postEntity.getUser(), AlarmType.NEW_COMMENT_ON_POST, new AlarmArgs(userEntity.getId(), postEntity.getId())));
     }
 


### PR DESCRIPTION
- PostEntity에 @Version 필드 추가 및 likeCount 필드 반영
- 좋아요 증가 시 낙관적 락(ObjectOptimisticLockingFailureException) 처리 및 재시도 로직 likeWithRetry() 구현
- PostService.like()에서 중복 좋아요 검사 및 likeCount 증가 반영
- ErrorCode에 낙관적 락 관련 에러 코드(OPTIMISTIC_LOCK_CONFLICT, CONFLICT_LIKE) 추가
- PostResponse에 likeCount 추가
- Controller에서 likeWithRetry() 호출로 변경
- LikeEntityRepository에 existsByUserAndPost() 및 deleteLike() 추가

기존 좋아요 기능의 동시성 이슈를 해결하고, 안정적인 카운트 반영을 위한 낙관적 락 처리 적용