### PR TITLE
feat: Kafka 기반 비동기 좋아요 기능 및 Redis 캐시 반영 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/src/main/java/sns/snsproject/configuration/filter/KafkaConfig.java
+++ b/src/main/java/sns/snsproject/configuration/filter/KafkaConfig.java
@@ -1,0 +1,51 @@
+package sns.snsproject.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    // Kafka Producer 설정
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // Kafka Consumer 설정 (옵션 - Spring Boot가 자동 설정하기도 함)
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "like-consumer");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    // Kafka 메시지 JSON 변환용 ObjectMapper
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/sns/snsproject/controller/PostController.java
+++ b/src/main/java/sns/snsproject/controller/PostController.java
@@ -67,7 +67,8 @@ public class PostController {
 
     @PostMapping("/{postId}/likes")
     public Response<Void> like(@PathVariable Long postId, Authentication authentication) {
-        postService.likeWithRetry(postId, authentication.getName());
+//        postService.likeWithRetry(postId, authentication.getName());
+        postService.likes(postId, authentication.getName());
         return Response.success();
     }
 

--- a/src/main/java/sns/snsproject/controller/request/PostCreateRequest.java
+++ b/src/main/java/sns/snsproject/controller/request/PostCreateRequest.java
@@ -3,9 +3,11 @@ package sns.snsproject.controller.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PostCreateRequest {
 
     private String title;

--- a/src/main/java/sns/snsproject/controller/request/PostModifyRequest.java
+++ b/src/main/java/sns/snsproject/controller/request/PostModifyRequest.java
@@ -2,9 +2,11 @@ package sns.snsproject.controller.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PostModifyRequest {
 
     private String title;

--- a/src/main/java/sns/snsproject/controller/request/UserJoinRequest.java
+++ b/src/main/java/sns/snsproject/controller/request/UserJoinRequest.java
@@ -2,9 +2,11 @@ package sns.snsproject.controller.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class UserJoinRequest {
 
     private String userName;

--- a/src/main/java/sns/snsproject/controller/request/UserLoginRequest.java
+++ b/src/main/java/sns/snsproject/controller/request/UserLoginRequest.java
@@ -2,9 +2,11 @@ package sns.snsproject.controller.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class UserLoginRequest {
 
     private String userName;

--- a/src/main/java/sns/snsproject/controller/response/UserLoginResponse.java
+++ b/src/main/java/sns/snsproject/controller/response/UserLoginResponse.java
@@ -2,9 +2,11 @@ package sns.snsproject.controller.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class UserLoginResponse {
 
    private String token;

--- a/src/main/java/sns/snsproject/model/LikeEvent.java
+++ b/src/main/java/sns/snsproject/model/LikeEvent.java
@@ -1,0 +1,13 @@
+package sns.snsproject.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeEvent {
+    private Long postId;
+    private String userName;
+}

--- a/src/main/java/sns/snsproject/model/entity/LikeEntity.java
+++ b/src/main/java/sns/snsproject/model/entity/LikeEntity.java
@@ -3,19 +3,19 @@ package sns.snsproject.model.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 
 @Entity
-@Table(name = "\"likes\"")
+@Table(name = "\"likes\"", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "post_id"})
+})
 @Getter
 @Setter
-@SQLDelete(sql = "UPDATE likes SET deleted_at = NOW() where id=?")
+//@SQLDelete(sql = "UPDATE likes SET deleted_at = NOW() where id=?")
 //@Where(clause = "deleted_at is NULL")
-@SQLRestriction("deleted_at is NULL")
+//@SQLRestriction("deleted_at is NULL")
 public class LikeEntity {
 
     @Id
@@ -33,21 +33,21 @@ public class LikeEntity {
     @Column(name = "registered_at")
     private Timestamp registeredAt;
 
-    @Column(name = "updated_at")
-    private Timestamp updatedAt;
-
-    @Column(name = "deleted_at")
-    private Timestamp deletedAt;
+//    @Column(name = "updated_at")
+//    private Timestamp updatedAt;
+//
+//    @Column(name = "deleted_at")
+//    private Timestamp deletedAt;
 
     @PrePersist
     void registeredAT() {
         this.registeredAt = Timestamp.from(Instant.now());
     }
 
-    @PreUpdate
-    void updatedAt() {
-        this.updatedAt = Timestamp.from(Instant.now());
-    }
+//    @PreUpdate
+//    void updatedAt() {
+//        this.updatedAt = Timestamp.from(Instant.now());
+//    }
 
     public static LikeEntity of(UserEntity user, PostEntity post) {
         LikeEntity entity = new LikeEntity();

--- a/src/main/java/sns/snsproject/model/entity/PostEntity.java
+++ b/src/main/java/sns/snsproject/model/entity/PostEntity.java
@@ -44,9 +44,9 @@ public class PostEntity {
     @Column(name = "like_count")
     private Integer likeCount = 0;
 
-    @Version
-    @Column(name = "version")
-    private Long version;
+//    @Version
+//    @Column(name = "version")
+//    private Long version;
 
     @PrePersist
     void registeredAT() {
@@ -66,6 +66,10 @@ public class PostEntity {
         if (this.likeCount > 0) {
             this.likeCount--;
         }
+    }
+
+    public void setLikeCount(int count) {
+        this.likeCount = count;
     }
 
     public static PostEntity of(String title, String body, UserEntity user) {

--- a/src/main/java/sns/snsproject/repository/LikeEntityRepository.java
+++ b/src/main/java/sns/snsproject/repository/LikeEntityRepository.java
@@ -5,26 +5,29 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 import sns.snsproject.model.entity.LikeEntity;
 import sns.snsproject.model.entity.PostEntity;
 import sns.snsproject.model.entity.UserEntity;
 
-import java.util.Optional;
-
 @Repository
 public interface LikeEntityRepository extends JpaRepository<LikeEntity, Long> {
 
-    Optional<LikeEntity> findByUserAndPost(UserEntity userEntity, PostEntity postEntity);
+//    Optional<LikeEntity> findByUserAndPost(UserEntity userEntity, PostEntity postEntity);
 
     @Query(value = "select count(*) from LikeEntity entity where entity.post = :post")
     long countByPost(@Param("post") PostEntity postEntity);
 
-    @Transactional
-    @Modifying
-    @Query("DELETE FROM LikeEntity where id = :likeId")
-    void deleteLike(@Param("likeId") Long likeId);
+//    @Transactional
+//    @Modifying
+//    @Query("DELETE FROM LikeEntity where id = :likeId")
+//    void deleteLike(@Param("likeId") Long likeId);
 
     @Query("SELECT COUNT(e) > 0 FROM LikeEntity e WHERE e.user = :user AND e.post.id = :postId")
     boolean existsByUserAndPost(@Param("user") UserEntity user, @Param("postId") Long postId);
+
+    @Modifying
+    @Query("delete from LikeEntity e where e.user = :user AND e.post.id = :postId")
+    void deleteByUserAndPost(UserEntity user, Long postId);
+
+//    boolean existsByUserAndPost(UserEntity user, Long postId);
 }

--- a/src/main/java/sns/snsproject/service/LikeEventListener.java
+++ b/src/main/java/sns/snsproject/service/LikeEventListener.java
@@ -1,0 +1,81 @@
+package sns.snsproject.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import sns.snsproject.model.AlarmArgs;
+import sns.snsproject.model.AlarmType;
+import sns.snsproject.model.LikeEvent;
+import sns.snsproject.model.entity.AlarmEntity;
+import sns.snsproject.model.entity.LikeEntity;
+import sns.snsproject.model.entity.PostEntity;
+import sns.snsproject.model.entity.UserEntity;
+import sns.snsproject.repository.AlarmEntityRepository;
+import sns.snsproject.repository.LikeEntityRepository;
+import sns.snsproject.repository.PostEntityRepository;
+import sns.snsproject.repository.UserEntityRepository;
+
+@Component
+@RequiredArgsConstructor
+public class LikeEventListener {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private final UserEntityRepository userEntityRepository;
+    private final PostEntityRepository postEntityRepository;
+    private final LikeEntityRepository likeEntityRepository;
+    private final AlarmEntityRepository alarmEntityRepository;
+
+    private static final String LIKE_KEY_FORMAT = "post:%d:likes";
+
+    @KafkaListener(topics = "like-topic", groupId = "like-consumer")
+    @Transactional
+    public void consume(String message) {
+        try {
+            // 1. Kafka 메시지 역직렬화
+            LikeEvent event = objectMapper.readValue(message, LikeEvent.class);
+
+            Long postId = event.getPostId();
+            String userName = event.getUserName();
+
+            // 2. 사용자, 게시글 조회
+            UserEntity user = userEntityRepository.findByUserName(userName)
+                    .orElseThrow(() -> new RuntimeException("사용자 없음"));
+            PostEntity post = postEntityRepository.findById(postId)
+                    .orElseThrow(() -> new RuntimeException("게시글 없음"));
+
+            // 3. 중복 좋아요 검사
+            boolean alreadyLiked = likeEntityRepository.existsByUserAndPost(user, postId);
+            if (alreadyLiked) {
+                likeEntityRepository.deleteByUserAndPost(user, postId);
+            } else {
+                // 4. 좋아요 저장
+                likeEntityRepository.save(LikeEntity.of(user, post));
+
+                // 5. 알람 저장
+                alarmEntityRepository.save(AlarmEntity.of(
+                        post.getUser(),
+                        AlarmType.NEW_LIKE_ON_POST,
+                        new AlarmArgs(user.getId(), post.getId())
+                ));
+            }
+
+
+            // 6. Redis → DB 동기화
+            String redisKey = String.format(LIKE_KEY_FORMAT, postId);
+            String likeCountStr = redisTemplate.opsForValue().get(redisKey);
+            int likeCount = likeCountStr != null && Integer.parseInt(likeCountStr) > 0 ? Integer.parseInt(likeCountStr) : 0;
+
+            post.setLikeCount(likeCount);
+            postEntityRepository.save(post);
+
+        } catch (Exception e) {
+            // 예외 로깅
+            System.err.println("❌ Kafka 메시지 처리 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/sns/snsproject/service/PostService.java
+++ b/src/main/java/sns/snsproject/service/PostService.java
@@ -1,11 +1,15 @@
 package sns.snsproject.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -13,10 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sns.snsproject.controller.response.PostResponse;
 import sns.snsproject.exception.ErrorCode;
 import sns.snsproject.exception.SnsApplicationException;
-import sns.snsproject.model.AlarmArgs;
-import sns.snsproject.model.AlarmType;
-import sns.snsproject.model.Comment;
-import sns.snsproject.model.Post;
+import sns.snsproject.model.*;
 import sns.snsproject.model.entity.*;
 import sns.snsproject.repository.*;
 import sns.snsproject.util.RedisStorage;
@@ -37,7 +38,10 @@ public class PostService {
     private final CommentEntityRepository commentEntityRepository;
     private final AlarmEntityRepository alarmEntityRepository;
     private final RedisStorage redisStorage;
-    private final FollowEntityRepository followEntityRepository;
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
 
     // Redis Sorted Set의 key
     private static final String REDIS_KEY = "post:views";
@@ -141,7 +145,7 @@ public class PostService {
             } catch (ObjectOptimisticLockingFailureException e) {
                 retry++;
                 System.out.println("🔁 낙관적 락 재시도 #" + retry);
-            }catch (SnsApplicationException e) {
+            } catch (SnsApplicationException e) {
                 long endTime = System.currentTimeMillis();
                 logFailure(userName, retry, endTime - startTime, e.getMessage());
                 return;
@@ -151,6 +155,7 @@ public class PostService {
         long endTime = System.currentTimeMillis();
         logFailure(userName, retry, endTime - startTime, "재시도 초과");
     }
+
     private void logSuccess(String userName, int retry, long durationMs) {
         System.out.printf("[Thread-%s] ✅ 성공 | 재시도: %d회 | 소요시간: %dms%n", userName, retry, durationMs);
     }
@@ -177,10 +182,47 @@ public class PostService {
         alarmEntityRepository.save(AlarmEntity.of(postEntity.getUser(), AlarmType.NEW_COMMENT_ON_POST, new AlarmArgs(userEntity.getId(), postEntity.getId())));
     }
 
+    private static final String LIKE_KEY_FORMAT = "post:%d:likes";
+
+    public void likes(Long postId, String userName) {
+        // Redis 키 구성: post:{postId}:likes
+        String redisKey = String.format(LIKE_KEY_FORMAT, postId);
+
+        // 좋아요 중복 시 좋아요 개수 감소
+        boolean alreadyLiked = likeEntityRepository.existsByUserAndPost(getUserEntityOrException(userName), postId);
+        if (alreadyLiked) {
+            redisTemplate.opsForValue().decrement(redisKey);
+        } else {
+            // Redis에서 좋아요 수 증가
+            redisTemplate.opsForValue().increment(redisKey);
+        }
+
+
+        // 2. Kafka 이벤트 전송
+        LikeEvent event = new LikeEvent(postId, userName);
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            kafkaTemplate.send("like-topic", message);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Kafka 메시지 직렬화 실패", e);
+        }
+    }
+
     @Transactional
     public long likeCount(Long postId) {
-        PostEntity postEntity = getPostEntityOrException(postId);
-        return likeEntityRepository.countByPost(postEntity);
+//        PostEntity postEntity = getPostEntityOrException(postId);
+//        return likeEntityRepository.countByPost(postEntity);
+        String key = String.format("post:%d:likes", postId);
+        String countStr = redisTemplate.opsForValue().get(key);
+
+        if (countStr != null) {
+            return Integer.parseInt(countStr);
+        }
+
+        // Redis에 없을 경우 DB fallback (선택적)
+        return postEntityRepository.findById(postId)
+                .map(PostEntity::getLikeCount)
+                .orElse(0);
     }
 
     @Transactional


### PR DESCRIPTION
- Kafka 설정 및 KafkaTemplate, ObjectMapper Bean 등록
- LikeEvent 클래스 생성 및 Kafka 이벤트 모델 정의
- PostService.likes() 메서드 추가: Redis 좋아요 수 증가/감소 처리 및 Kafka 메시지 전송
- LikeEventListener 추가: Kafka 메시지 수신 후 LikeEntity 저장/삭제 및 AlarmEntity 저장 처리
- 게시글의 likeCount 값을 Redis → DB로 동기화
- Redis 좋아요 수 조회 로직을 likeCount()에 적용
- Controller에서 likeWithRetry() → likes()로 변경
- LikeEntity, PostEntity 엔티티 수정 및 낙관적 락 제거
- build.gradle: spring-kafka, jackson-databind 의존성 추가
- docker-compose.yml: Kafka, Zookeeper 컨테이너 설정 추가